### PR TITLE
Add a setting to discard screen saver mode while playing music

### DIFF
--- a/lcdmain.py
+++ b/lcdmain.py
@@ -86,7 +86,10 @@ def getLcdMode():
   if navActive:
     ret = LCD_MODE.LCD_MODE_NAVIGATION
   elif screenSaver:
-    ret = LCD_MODE.LCD_MODE_SCREENSAVER
+    if playingMusic and not settings_getScreenSaverPlayingMusic():
+      ret = LCD_MODE.LCD_MODE_MUSIC
+    else:
+      ret = LCD_MODE.LCD_MODE_SCREENSAVER
   elif playingPVRTV:
     ret = LCD_MODE.LCD_MODE_PVRTV
   elif playingPVRRadio:

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -10,6 +10,7 @@
   <string id="32105">Use alternate charset</string>
   <string id="32106">Charset</string>
   <string id="32107">Support for extra display elements (e.g. icons)</string>
+  <string id="32108">Switch to screen saver mode while playing music</string>
 
   <!--Backlight-->
   <string id="32200">Backlight</string>

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -51,6 +51,7 @@ global g_hideconnpopups
 global g_usealternatecharset
 global g_charset
 global g_useextraelements
+global g_screensaverplayingmusic
 
 #init globals with defaults
 def settings_initGlobals():
@@ -72,25 +73,27 @@ def settings_initGlobals():
   global g_usealternatecharset
   global g_charset
   global g_useextraelements
+  global g_screensaverplayingmusic
 
-  g_hostip              = "127.0.0.1"
-  g_hostport            = 13666
-  g_timer               = time.time()   
-  g_heartbeat           = False
-  g_scrolldelay         = 1
-  g_scrollmode          = "0"
-  g_settingsChanged     = True
-  g_dimonscreensaver    = False
-  g_dimonshutdown       = False
-  g_dimonvideoplayback  = False
-  g_dimonmusicplayback  = False
-  g_dimdelay            = 0
-  g_navtimeout          = 3
-  g_refreshrate         = 1
-  g_hideconnpopups      = True
-  g_usealternatecharset = False
-  g_charset             = "iso-8859-1"
-  g_useextraelements    = True
+  g_hostip                  = "127.0.0.1"
+  g_hostport                = 13666
+  g_timer                   = time.time()   
+  g_heartbeat               = False
+  g_scrolldelay             = 1
+  g_scrollmode              = "0"
+  g_settingsChanged         = True
+  g_dimonscreensaver        = False
+  g_dimonshutdown           = False
+  g_dimonvideoplayback      = False
+  g_dimonmusicplayback      = False
+  g_dimdelay                = 0
+  g_navtimeout              = 3
+  g_refreshrate             = 1
+  g_hideconnpopups          = True
+  g_usealternatecharset     = False
+  g_charset                 = "iso-8859-1"
+  g_useextraelements        = True
+  g_screensaverplayingmusic = True
 
 def settings_getHostIp():
   global g_hostip
@@ -107,6 +110,10 @@ def settings_getHeartBeat():
 def settings_getUseExtraElements():
   global g_useextraelements
   return g_useextraelements
+
+def settings_getScreenSaverPlayingMusic():
+  global g_screensaverplayingmusic
+  return g_screensaverplayingmusic
 
 def settings_getScrollDelay():
   global g_scrolldelay
@@ -266,6 +273,7 @@ def settings_handleLcdSettings():
   global g_hideconnpopups
   global g_usealternatecharset
   global g_charset
+  global g_screensaverplayingmusic
 
   g_settingsChanged = False
 
@@ -281,6 +289,7 @@ def settings_handleLcdSettings():
   hideconnpopups = __settings__.getSetting("hideconnpopups") == "true"
   usealternatecharset = __settings__.getSetting("usealternatecharset") == "true"
   charset = __settings__.getSetting("charset")
+  screensaverplayingmusic = __settings__.getSetting("screensaverplayingmusic") == "true"
 
   if g_scrolldelay != scrolldelay:
     g_scrolldelay = scrolldelay
@@ -332,6 +341,10 @@ def settings_handleLcdSettings():
 
   if g_charset != charset:
     g_charset = charset
+    g_settingsChanged = True
+
+  if g_screensaverplayingmusic != screensaverplayingmusic:
+    g_screensaverplayingmusic = screensaverplayingmusic
     g_settingsChanged = True
 
 #handles all settings and applies them as needed

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,8 @@
     <setting id="charset" enable="eq(-1,true)" type="enum" label="32106" lvalues="32411|32412|32413|32414|32415|32416|32417" default="0" subsetting="true"/>
     <setting id="sep2" type="sep" />
     <setting id="useextraelements" type="bool" label="32107" default="true" />
+    <setting id="sep2" type="sep" />
+    <setting id="screensaverplayingmusic" type="bool" label="32108" default="true" />
   </category>
   <category label="32200">
     <setting label="32206" type="lsep" />


### PR DESCRIPTION
While playing music, when Kodi enters screen saver mode, the playing time is displayed, but the user can't check current song or duration on the LCD.

This commit adds a setting to control whether the LCDProc Addon should switch to screen saver screen while playing music (defaults to current behaviour: true).